### PR TITLE
Remove ECJ dependency

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
   id("org.metaborg.spoofax.gradle.langspec") apply false // No version: use the plugin from the included composite build
   id("org.metaborg.spoofax.gradle.project") apply false
   id("org.metaborg.spoofax.gradle.test") apply false
-  id("de.set.ecj") version "1.4.1" apply false
 }
 
 subprojects {


### PR DESCRIPTION
This PR removes the ECJ build dependency because [the plugin](https://github.com/TwoStone/gradle-eclipse-compiler-plugin) is severely out of date, deprecated, and not supported in recent Gradle versions.